### PR TITLE
Option to set Priority and Affinity

### DIFF
--- a/KeyboardHook.cs
+++ b/KeyboardHook.cs
@@ -44,7 +44,7 @@ namespace SandsTrilogyKiller
                         Process proc = Process.Start(GameLauncherPath);
                         if (PriorityAffinity)
                         {
-                            proc.ProcessorAffinity = (System.IntPtr)0x08;
+                            proc.ProcessorAffinity = (System.IntPtr)0x01;
                             proc.PriorityClass = ProcessPriorityClass.RealTime;
                         }
                     }

--- a/KeyboardHook.cs
+++ b/KeyboardHook.cs
@@ -17,6 +17,10 @@ namespace SandsTrilogyKiller
         public Keys Hotkey { get; set; }
         public bool PriorityAffinity { get; set; }
 
+        public ProcessPriorityClass Priority { get; set; }
+
+        public System.IntPtr Affinity { get; set; }
+
         public KeyboardHook()
         {
             proc = HookCallback;
@@ -44,8 +48,8 @@ namespace SandsTrilogyKiller
                         Process proc = Process.Start(GameLauncherPath);
                         if (PriorityAffinity)
                         {
-                            proc.ProcessorAffinity = (System.IntPtr)0x01;
-                            proc.PriorityClass = ProcessPriorityClass.RealTime;
+                            proc.ProcessorAffinity = Affinity;
+                            proc.PriorityClass = Priority;
                         }
                     }
                     catch

--- a/KeyboardHook.cs
+++ b/KeyboardHook.cs
@@ -15,6 +15,7 @@ namespace SandsTrilogyKiller
         public int killerSpeed = 0;
         public string GameLauncherPath { get; set; }
         public Keys Hotkey { get; set; }
+        public bool PriorityAffinity { get; set; }
 
         public KeyboardHook()
         {
@@ -40,7 +41,12 @@ namespace SandsTrilogyKiller
                     try
                     {
                         System.Threading.Thread.Sleep(killerSpeed);
-                        Process.Start(GameLauncherPath);
+                        Process proc = Process.Start(GameLauncherPath);
+                        if (PriorityAffinity)
+                        {
+                            proc.ProcessorAffinity = (System.IntPtr)0x08;
+                            proc.PriorityClass = ProcessPriorityClass.RealTime;
+                        }
                     }
                     catch
                     {

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -19,6 +19,18 @@ namespace SandsTrilogyKiller
             txtPathWW.Text = Properties.Settings.Default.pathWW;
             txtPathT2T.Text = Properties.Settings.Default.pathT2T;
             SetGameLauncherPath();
+
+            int coreCount = Environment.ProcessorCount;
+            int i = 0;
+            while (i < coreCount)
+            {
+                affinityComboBox.Items.Add("CPU " + i.ToString());
+                i++;
+            }
+            priorityComboBox.SelectedIndex = 1;
+            affinityComboBox.SelectedIndex = 0;
+            hook.Priority = ProcessPriorityClass.High;
+            hook.Affinity = (System.IntPtr)0x01;
             hook.PriorityAffinity = cboxPriorityAffinity.Checked;
         }
 
@@ -91,6 +103,13 @@ namespace SandsTrilogyKiller
                 String princeOfPersiaFile = hook.GameLauncherPath.Substring(0, hook.GameLauncherPath.Length - 7) + "PrinceOfPersia.EXE";
                 if (File.Exists(princeOfPersiaFile))
                 {
+                    if (Process.GetProcessesByName("PrinceOfPersia").Length > 0)
+                    {
+                        foreach (var process in Process.GetProcessesByName("PrinceOfPersia"))
+                        {
+                            process.Kill();
+                        }
+                    }
                     try
                     {
                         Process.Start(princeOfPersiaFile);
@@ -134,6 +153,25 @@ namespace SandsTrilogyKiller
         private void cboxPriorityAffinity_CheckStateChanged(object sender, EventArgs e)
         {
             hook.PriorityAffinity = cboxPriorityAffinity.Checked;
+        }
+
+        private void priorityComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            switch (priorityComboBox.SelectedIndex)
+            {
+                case 0: hook.Priority = ProcessPriorityClass.RealTime; break;
+                case 1: hook.Priority = ProcessPriorityClass.High; break;
+                case 2: hook.Priority = ProcessPriorityClass.AboveNormal; break;
+                case 3: hook.Priority = ProcessPriorityClass.Normal; break;
+                case 4: hook.Priority = ProcessPriorityClass.BelowNormal; break;
+                case 5: hook.Priority = ProcessPriorityClass.Idle; break;
+                default: break;
+            }
+        }
+
+        private void affinityComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            hook.Affinity = (System.IntPtr)Math.Pow(2, affinityComboBox.SelectedIndex);
         }
     }
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -19,7 +19,7 @@ namespace SandsTrilogyKiller
             txtPathWW.Text = Properties.Settings.Default.pathWW;
             txtPathT2T.Text = Properties.Settings.Default.pathT2T;
             SetGameLauncherPath();
-            hook.PriorityAffinity = checkBox1.Checked;
+            hook.PriorityAffinity = cboxPriorityAffinity.Checked;
         }
 
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
@@ -131,9 +131,9 @@ namespace SandsTrilogyKiller
             labelKillerDelayMs.Text = trackBarKillerDelay.Value.ToString() + " ms";
         }
 
-        private void checkBox1_CheckStateChanged(object sender, EventArgs e)
+        private void cboxPriorityAffinity_CheckStateChanged(object sender, EventArgs e)
         {
-            hook.PriorityAffinity = checkBox1.Checked;
+            hook.PriorityAffinity = cboxPriorityAffinity.Checked;
         }
     }
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -19,6 +19,7 @@ namespace SandsTrilogyKiller
             txtPathWW.Text = Properties.Settings.Default.pathWW;
             txtPathT2T.Text = Properties.Settings.Default.pathT2T;
             SetGameLauncherPath();
+            hook.PriorityAffinity = checkBox1.Checked;
         }
 
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
@@ -128,6 +129,11 @@ namespace SandsTrilogyKiller
         {
             hook.killerSpeed = trackBarKillerDelay.Value;
             labelKillerDelayMs.Text = trackBarKillerDelay.Value.ToString() + " ms";
+        }
+
+        private void checkBox1_CheckStateChanged(object sender, EventArgs e)
+        {
+            hook.PriorityAffinity = checkBox1.Checked;
         }
     }
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -21,16 +21,20 @@ namespace SandsTrilogyKiller
             SetGameLauncherPath();
 
             int coreCount = Environment.ProcessorCount;
-            int i = 0;
-            while (i < coreCount)
+            for (int i = 0;  i < coreCount; i++) affinityComboBox.Items.Add("CPU " + i.ToString());
+            hook.Priority = Properties.Settings.Default.priority;
+            hook.Affinity = (System.IntPtr)Properties.Settings.Default.affinity;
+            switch (Properties.Settings.Default.priority)
             {
-                affinityComboBox.Items.Add("CPU " + i.ToString());
-                i++;
+                case ProcessPriorityClass.RealTime      : priorityComboBox.SelectedIndex = 0; break;
+                case ProcessPriorityClass.High          : priorityComboBox.SelectedIndex = 1; break;
+                case ProcessPriorityClass.AboveNormal   : priorityComboBox.SelectedIndex = 2; break;
+                case ProcessPriorityClass.Normal        : priorityComboBox.SelectedIndex = 3; break;
+                case ProcessPriorityClass.BelowNormal   : priorityComboBox.SelectedIndex = 4; break;
+                case ProcessPriorityClass.Idle          : priorityComboBox.SelectedIndex = 5; break;
+                default                                 : break;
             }
-            priorityComboBox.SelectedIndex = 1;
-            affinityComboBox.SelectedIndex = 0;
-            hook.Priority = ProcessPriorityClass.High;
-            hook.Affinity = (System.IntPtr)0x01;
+            affinityComboBox.SelectedIndex = (int)Math.Log(Properties.Settings.Default.affinity, 2);
             hook.PriorityAffinity = cboxPriorityAffinity.Checked;
         }
 
@@ -41,6 +45,8 @@ namespace SandsTrilogyKiller
             Properties.Settings.Default.pathSoT = txtPathSoT.Text;
             Properties.Settings.Default.pathWW = txtPathWW.Text;
             Properties.Settings.Default.pathT2T = txtPathT2T.Text;
+            Properties.Settings.Default.priority = hook.Priority;
+            Properties.Settings.Default.affinity = (int)hook.Affinity;
             Properties.Settings.Default.Save();
         }
 
@@ -95,7 +101,7 @@ namespace SandsTrilogyKiller
             }
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void btnReady_Click(object sender, EventArgs e)
         {
             
             if (hook.GameLauncherPath == txtPathSoT.Text)

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SandsTrilogyKiller.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -80,6 +80,30 @@ namespace SandsTrilogyKiller.Properties {
             }
             set {
                 this["hotkey"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("High")]
+        public global::System.Diagnostics.ProcessPriorityClass priority {
+            get {
+                return ((global::System.Diagnostics.ProcessPriorityClass)(this["priority"]));
+            }
+            set {
+                this["priority"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int affinity {
+            get {
+                return ((int)(this["affinity"]));
+            }
+            set {
+                this["affinity"] = value;
             }
         }
     }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -17,5 +17,11 @@
     <Setting Name="hotkey" Type="System.Windows.Forms.Keys" Scope="User">
       <Value Profile="(Default)">NumPad5</Value>
     </Setting>
+    <Setting Name="priority" Type="System.Diagnostics.ProcessPriorityClass" Scope="User">
+      <Value Profile="(Default)">High</Value>
+    </Setting>
+    <Setting Name="affinity" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/SandsTrilogyKiller.csproj
+++ b/SandsTrilogyKiller.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/SandsTrilogyKiller.csproj
+++ b/SandsTrilogyKiller.csproj
@@ -31,6 +31,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -66,6 +69,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <None Include="app.config" />
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/app.config
+++ b/app.config
@@ -22,6 +22,12 @@
             <setting name="hotkey" serializeAs="String">
                 <value>NumPad5</value>
             </setting>
+            <setting name="priority" serializeAs="String">
+                <value>High</value>
+            </setting>
+            <setting name="affinity" serializeAs="String">
+                <value>1</value>
+            </setting>
         </SandsTrilogyKiller.Properties.Settings>
     </userSettings>
 </configuration>

--- a/app.manifest
+++ b/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+		  <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/mainForm.Designer.cs
+++ b/mainForm.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.txtPathSoT = new System.Windows.Forms.TextBox();
             this.txtPathWW = new System.Windows.Forms.TextBox();
             this.btnChangePathSoT = new System.Windows.Forms.Button();
@@ -46,7 +47,13 @@
             this.labelKillerDelay = new System.Windows.Forms.Label();
             this.labelKillerDelayMs = new System.Windows.Forms.Label();
             this.cboxPriorityAffinity = new System.Windows.Forms.CheckBox();
+            this.contextMenuPriorityAffinity = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.priorityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.priorityComboBox = new System.Windows.Forms.ToolStripComboBox();
+            this.affinityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.affinityComboBox = new System.Windows.Forms.ToolStripComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarKillerDelay)).BeginInit();
+            this.contextMenuPriorityAffinity.SuspendLayout();
             this.SuspendLayout();
             // 
             // txtPathSoT
@@ -188,7 +195,7 @@
             this.btnReady.Name = "btnReady";
             this.btnReady.Size = new System.Drawing.Size(79, 29);
             this.btnReady.TabIndex = 12;
-            this.btnReady.Text = "ready";
+            this.btnReady.Text = "Ready";
             this.btnReady.UseVisualStyleBackColor = true;
             this.btnReady.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -227,8 +234,7 @@
             // cboxPriorityAffinity
             // 
             this.cboxPriorityAffinity.AutoSize = true;
-            this.cboxPriorityAffinity.Checked = true;
-            this.cboxPriorityAffinity.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cboxPriorityAffinity.ContextMenuStrip = this.contextMenuPriorityAffinity;
             this.cboxPriorityAffinity.Location = new System.Drawing.Point(301, 41);
             this.cboxPriorityAffinity.Name = "cboxPriorityAffinity";
             this.cboxPriorityAffinity.Size = new System.Drawing.Size(131, 17);
@@ -236,6 +242,49 @@
             this.cboxPriorityAffinity.Text = "Set Priority and Affinity";
             this.cboxPriorityAffinity.UseVisualStyleBackColor = true;
             this.cboxPriorityAffinity.CheckStateChanged += new System.EventHandler(this.cboxPriorityAffinity_CheckStateChanged);
+            // 
+            // contextMenuPriorityAffinity
+            // 
+            this.contextMenuPriorityAffinity.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.priorityToolStripMenuItem,
+            this.affinityToolStripMenuItem});
+            this.contextMenuPriorityAffinity.Name = "contextMenuStrip1";
+            this.contextMenuPriorityAffinity.Size = new System.Drawing.Size(181, 70);
+            // 
+            // priorityToolStripMenuItem
+            // 
+            this.priorityToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.priorityComboBox});
+            this.priorityToolStripMenuItem.Name = "priorityToolStripMenuItem";
+            this.priorityToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.priorityToolStripMenuItem.Text = "Priority";
+            // 
+            // priorityComboBox
+            // 
+            this.priorityComboBox.Items.AddRange(new object[] {
+            "Realtime",
+            "High",
+            "Above normal",
+            "Normal",
+            "Below normal",
+            "Low"});
+            this.priorityComboBox.Name = "priorityComboBox";
+            this.priorityComboBox.Size = new System.Drawing.Size(121, 23);
+            this.priorityComboBox.SelectedIndexChanged += new System.EventHandler(this.priorityComboBox_SelectedIndexChanged);
+            // 
+            // affinityToolStripMenuItem
+            // 
+            this.affinityToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.affinityComboBox});
+            this.affinityToolStripMenuItem.Name = "affinityToolStripMenuItem";
+            this.affinityToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.affinityToolStripMenuItem.Text = "Affinity";
+            // 
+            // affinityComboBox
+            // 
+            this.affinityComboBox.Name = "affinityComboBox";
+            this.affinityComboBox.Size = new System.Drawing.Size(121, 23);
+            this.affinityComboBox.SelectedIndexChanged += new System.EventHandler(this.affinityComboBox_SelectedIndexChanged);
             // 
             // MainForm
             // 
@@ -266,6 +315,7 @@
             this.Text = "SandsTrilogyKiller";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
             ((System.ComponentModel.ISupportInitialize)(this.trackBarKillerDelay)).EndInit();
+            this.contextMenuPriorityAffinity.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -291,6 +341,11 @@
         private System.Windows.Forms.Label labelKillerDelay;
         private System.Windows.Forms.Label labelKillerDelayMs;
         public System.Windows.Forms.CheckBox cboxPriorityAffinity;
+        private System.Windows.Forms.ContextMenuStrip contextMenuPriorityAffinity;
+        private System.Windows.Forms.ToolStripMenuItem priorityToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem affinityToolStripMenuItem;
+        private System.Windows.Forms.ToolStripComboBox affinityComboBox;
+        private System.Windows.Forms.ToolStripComboBox priorityComboBox;
     }
 }
 

--- a/mainForm.Designer.cs
+++ b/mainForm.Designer.cs
@@ -1,6 +1,6 @@
 ﻿namespace SandsTrilogyKiller
 {
-    partial class MainForm
+    public partial class MainForm
     {
         /// <summary>
         /// Required designer variable.
@@ -45,6 +45,7 @@
             this.trackBarKillerDelay = new System.Windows.Forms.TrackBar();
             this.labelKillerDelay = new System.Windows.Forms.Label();
             this.labelKillerDelayMs = new System.Windows.Forms.Label();
+            this.checkBox1 = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarKillerDelay)).BeginInit();
             this.SuspendLayout();
             // 
@@ -223,11 +224,25 @@
             this.labelKillerDelayMs.TabIndex = 18;
             this.labelKillerDelayMs.Text = "0 ms";
             // 
+            // checkBox1
+            // 
+            this.checkBox1.AutoSize = true;
+            this.checkBox1.Checked = true;
+            this.checkBox1.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBox1.Location = new System.Drawing.Point(301, 41);
+            this.checkBox1.Name = "checkBox1";
+            this.checkBox1.Size = new System.Drawing.Size(131, 17);
+            this.checkBox1.TabIndex = 19;
+            this.checkBox1.Text = "Set Priority and Affinity";
+            this.checkBox1.UseVisualStyleBackColor = true;
+            this.checkBox1.CheckStateChanged += new System.EventHandler(this.checkBox1_CheckStateChanged);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(439, 188);
+            this.Controls.Add(this.checkBox1);
             this.Controls.Add(this.btnChangePathSoT);
             this.Controls.Add(this.txtPathSoT);
             this.Controls.Add(this.lblPathSoT);
@@ -275,6 +290,7 @@
         private System.Windows.Forms.TrackBar trackBarKillerDelay;
         private System.Windows.Forms.Label labelKillerDelay;
         private System.Windows.Forms.Label labelKillerDelayMs;
+        public System.Windows.Forms.CheckBox checkBox1;
     }
 }
 

--- a/mainForm.Designer.cs
+++ b/mainForm.Designer.cs
@@ -45,7 +45,7 @@
             this.trackBarKillerDelay = new System.Windows.Forms.TrackBar();
             this.labelKillerDelay = new System.Windows.Forms.Label();
             this.labelKillerDelayMs = new System.Windows.Forms.Label();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
+            this.cboxPriorityAffinity = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarKillerDelay)).BeginInit();
             this.SuspendLayout();
             // 
@@ -224,25 +224,25 @@
             this.labelKillerDelayMs.TabIndex = 18;
             this.labelKillerDelayMs.Text = "0 ms";
             // 
-            // checkBox1
+            // cboxPriorityAffinity
             // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Checked = true;
-            this.checkBox1.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox1.Location = new System.Drawing.Point(301, 41);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(131, 17);
-            this.checkBox1.TabIndex = 19;
-            this.checkBox1.Text = "Set Priority and Affinity";
-            this.checkBox1.UseVisualStyleBackColor = true;
-            this.checkBox1.CheckStateChanged += new System.EventHandler(this.checkBox1_CheckStateChanged);
+            this.cboxPriorityAffinity.AutoSize = true;
+            this.cboxPriorityAffinity.Checked = true;
+            this.cboxPriorityAffinity.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cboxPriorityAffinity.Location = new System.Drawing.Point(301, 41);
+            this.cboxPriorityAffinity.Name = "cboxPriorityAffinity";
+            this.cboxPriorityAffinity.Size = new System.Drawing.Size(131, 17);
+            this.cboxPriorityAffinity.TabIndex = 19;
+            this.cboxPriorityAffinity.Text = "Set Priority and Affinity";
+            this.cboxPriorityAffinity.UseVisualStyleBackColor = true;
+            this.cboxPriorityAffinity.CheckStateChanged += new System.EventHandler(this.cboxPriorityAffinity_CheckStateChanged);
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(439, 188);
-            this.Controls.Add(this.checkBox1);
+            this.Controls.Add(this.cboxPriorityAffinity);
             this.Controls.Add(this.btnChangePathSoT);
             this.Controls.Add(this.txtPathSoT);
             this.Controls.Add(this.lblPathSoT);
@@ -290,7 +290,7 @@
         private System.Windows.Forms.TrackBar trackBarKillerDelay;
         private System.Windows.Forms.Label labelKillerDelay;
         private System.Windows.Forms.Label labelKillerDelayMs;
-        public System.Windows.Forms.CheckBox checkBox1;
+        public System.Windows.Forms.CheckBox cboxPriorityAffinity;
     }
 }
 

--- a/mainForm.Designer.cs
+++ b/mainForm.Designer.cs
@@ -52,6 +52,7 @@
             this.priorityComboBox = new System.Windows.Forms.ToolStripComboBox();
             this.affinityToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.affinityComboBox = new System.Windows.Forms.ToolStripComboBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.trackBarKillerDelay)).BeginInit();
             this.contextMenuPriorityAffinity.SuspendLayout();
             this.SuspendLayout();
@@ -197,7 +198,7 @@
             this.btnReady.TabIndex = 12;
             this.btnReady.Text = "Ready";
             this.btnReady.UseVisualStyleBackColor = true;
-            this.btnReady.Click += new System.EventHandler(this.button1_Click);
+            this.btnReady.Click += new System.EventHandler(this.btnReady_Click);
             // 
             // trackBarKillerDelay
             // 
@@ -240,6 +241,7 @@
             this.cboxPriorityAffinity.Size = new System.Drawing.Size(131, 17);
             this.cboxPriorityAffinity.TabIndex = 19;
             this.cboxPriorityAffinity.Text = "Set Priority and Affinity";
+            this.toolTip1.SetToolTip(this.cboxPriorityAffinity, "Set custom priority and affinity while launching. Right click for more options.");
             this.cboxPriorityAffinity.UseVisualStyleBackColor = true;
             this.cboxPriorityAffinity.CheckStateChanged += new System.EventHandler(this.cboxPriorityAffinity_CheckStateChanged);
             // 
@@ -249,7 +251,7 @@
             this.priorityToolStripMenuItem,
             this.affinityToolStripMenuItem});
             this.contextMenuPriorityAffinity.Name = "contextMenuStrip1";
-            this.contextMenuPriorityAffinity.Size = new System.Drawing.Size(181, 70);
+            this.contextMenuPriorityAffinity.Size = new System.Drawing.Size(114, 48);
             // 
             // priorityToolStripMenuItem
             // 
@@ -277,7 +279,7 @@
             this.affinityToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.affinityComboBox});
             this.affinityToolStripMenuItem.Name = "affinityToolStripMenuItem";
-            this.affinityToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.affinityToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
             this.affinityToolStripMenuItem.Text = "Affinity";
             // 
             // affinityComboBox
@@ -346,6 +348,7 @@
         private System.Windows.Forms.ToolStripMenuItem affinityToolStripMenuItem;
         private System.Windows.Forms.ToolStripComboBox affinityComboBox;
         private System.Windows.Forms.ToolStripComboBox priorityComboBox;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }
 

--- a/mainForm.resx
+++ b/mainForm.resx
@@ -120,4 +120,7 @@
   <metadata name="openFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="contextMenuPriorityAffinity.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>150, 17</value>
+  </metadata>
 </root>

--- a/mainForm.resx
+++ b/mainForm.resx
@@ -123,4 +123,7 @@
   <metadata name="contextMenuPriorityAffinity.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>150, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>351, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
When the checkbox is enabled, process priority is set to realtime and affinity will be set to one core. This apparently helps with avoiding crashes, more consistent tricks, etc.